### PR TITLE
Feature: Front End Cleanup

### DIFF
--- a/home_default/templates/home_default/base.html
+++ b/home_default/templates/home_default/base.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 {% load static %}
 <html lang="en">

--- a/home_default/templates/home_default/form_base.html
+++ b/home_default/templates/home_default/form_base.html
@@ -1,0 +1,11 @@
+{% extends 'home_default/base.html' %}
+{% block content %}
+<div class="container">
+    <div class="row mt-5">
+        <div class="col">
+            {% block form %}
+            {% endblock form %}
+        </div>
+    </div>
+</div>
+{% endblock content %}

--- a/trip/templates/trip/create_trip.html
+++ b/trip/templates/trip/create_trip.html
@@ -1,9 +1,10 @@
-{% extends "home_default/base.html" %}
+{% extends "home_default/form_base.html" %}
 {% load crispy_forms_tags %}
-{% block content %}
+{% block form %}
 <form method="POST">
     {% csrf_token %}
     {{ form | crispy }}
+    <br>
     <input type="submit" value="Submit" />
 </form>
-{% endblock content %}
+{% endblock form %}

--- a/trip/templates/trip/detail_trip.html
+++ b/trip/templates/trip/detail_trip.html
@@ -1,7 +1,7 @@
 {% extends "home_default/base.html" %}
 {% block content %}
 <div class="container">
-    <div class="row-gap-3">
+    <div class="row-gap-3 mt-5">
         <div class="col">
              <h4>Trip to {{ usertrip_instance.trip.destination_city }}, {{ usertrip_instance.trip.destination_country }}</h4>
                 <p>Start date: {{ usertrip_instance.start_trip|date:"m/d/Y" }}</p>

--- a/trip/templates/trip/milestone_confirm.html
+++ b/trip/templates/trip/milestone_confirm.html
@@ -1,8 +1,8 @@
-{% extends 'home_default/base.html' %}
-{% block content %}
-    <p>Are you sure you want to delete this trip? You will have to recreate it if you change your mind.</p>
-    <form method="POST">
-        {% csrf_token %}
-        <input type="submit" value="Confirm" />
-    </form>
-{% endblock content %}
+{% extends 'home_default/form_base.html' %}
+{% block form %}
+<p>Are you sure you want to delete this trip? You will have to recreate it if you change your mind.</p>
+<form method="POST">
+    {% csrf_token %}
+    <input type="submit" value="Confirm" />
+</form>
+{% endblock form %}

--- a/trip/templates/trip/update_trip.html
+++ b/trip/templates/trip/update_trip.html
@@ -1,9 +1,10 @@
-{% extends "home_default/base.html" %}
+{% extends "home_default/form_base.html" %}
 {% load crispy_forms_tags %}
-{% block content %}
+{% block form %}
 <form method="POST">
     {% csrf_token %}
     {{ usertrip_update_form | crispy }}
+    <br>
     <input type="submit" value="Submit" />
 </form>
-{% endblock content %}
+{% endblock form %}

--- a/trip/templates/trip/view_trips.html
+++ b/trip/templates/trip/view_trips.html
@@ -1,7 +1,7 @@
 {% extends "home_default/base.html" %}
 {% block content %}
 <div class="container">
-    <div class="row">
+    <div class="row mt-5">
         <div class="col">
             <h1>Your Trips</h1>
         </div>

--- a/user_profile/templates/user_profile/edit_profile.html
+++ b/user_profile/templates/user_profile/edit_profile.html
@@ -1,9 +1,10 @@
-{% extends 'home_default/base.html' %}
+{% extends 'home_default/form_base.html' %}
 {% load crispy_forms_tags %}
-{% block content %}
+{% block form %}
 <form method="POST">
     {% csrf_token %}
     {{ profile_form | crispy }}
+    <br>
     <input type="submit" value="Submit"/>
 </form>
-{% endblock content %}
+{% endblock form %}

--- a/user_profile/templates/user_profile/login.html
+++ b/user_profile/templates/user_profile/login.html
@@ -1,6 +1,6 @@
-{% extends 'home_default/base.html' %}
+{% extends 'home_default/form_base.html' %}
 {% load crispy_forms_tags %}
-{% block content %}
+{% block form %}
 <form method="POST">
     {% csrf_token %}
     <fieldset>
@@ -18,4 +18,4 @@
     <a href="{% url 'user_profile:reset_password' %}">Forgot Password</a>
 </small>
     <br>
-{% endblock content %}
+{% endblock form %}

--- a/user_profile/templates/user_profile/logout.html
+++ b/user_profile/templates/user_profile/logout.html
@@ -1,7 +1,7 @@
-{% extends 'home_default/base.html' %}
-{% block content %}
+{% extends 'home_default/form_base.html' %}
+{% block form %}
 <p>You have been logged out</p>
 <small>
     <a href="{% url 'user_profile:login' %}">Log In Again</a>
 </small>
-{% endblock content %}
+{% endblock form %}

--- a/user_profile/templates/user_profile/milestone_confirm.html
+++ b/user_profile/templates/user_profile/milestone_confirm.html
@@ -1,8 +1,8 @@
-{% extends 'home_default/base.html' %}
-{% block content %}
+{% extends 'home_default/form_base.html' %}
+{% block form %}
     <p>Are you sure you want to delete this account?</p>
     <form method="POST">
         {% csrf_token %}
         <input type="submit" value="Confirm" />
     </form>
-{% endblock content %}
+{% endblock form %}

--- a/user_profile/templates/user_profile/password_reset_form.html
+++ b/user_profile/templates/user_profile/password_reset_form.html
@@ -1,13 +1,13 @@
-{% extends 'home_default/base.html' %}
+{% extends 'home_default/form_base.html' %}
 {% load crispy_forms_tags %}
 {% load static %}
-{% block content %}
+{% block form %}
 <h1>Forgot your Password?</h1>
     <p>Enter your registered email address below. And we'll send you instructions for
     setting a new one.</p>
     <form method="POST">
         {% csrf_token %}
-        {{ form.as_p }}
+        {{ form | crispy }}
     <input type="submit" value="Send Email" class="border-primary">
     </form>
-{% endblock content %}
+{% endblock form %}

--- a/user_profile/templates/user_profile/upload_images.html
+++ b/user_profile/templates/user_profile/upload_images.html
@@ -1,6 +1,6 @@
-{% extends 'home_default/base.html' %}
+{% extends 'home_default/form_base.html' %}
 {% load crispy_forms_tags %}
-{% block content %}
+{% block form %}
 <form method="POST" enctype="multipart/form-data">
     {% csrf_token %}
     {{ image_formset.management_form }}
@@ -11,4 +11,4 @@
     {% endfor %}
     <input type="submit" value="Submit"/>
 </form>
-{% endblock content %}
+{% endblock form %}

--- a/user_profile/templates/user_profile/user_registration.html
+++ b/user_profile/templates/user_profile/user_registration.html
@@ -1,9 +1,9 @@
-{% extends 'home_default/base.html' %}
+{% extends 'home_default/form_base.html' %}
 {% load crispy_forms_tags %}
-{% block content %}
+{% block form %}
 <form method="POST">
     {% csrf_token %}
     {{ acc_form|crispy }}
     <input type="submit" value="Submit" />
 </form>
-{% endblock content %}
+{% endblock form %}


### PR DESCRIPTION
Created a new base template (form_base.html) to be used for formatting forms:

The template inherits from base.html (so it pulls in HTML boilerplate, our bootstrap tags, messages, navbar, etc.). It encapsulates the form into a div->row->col hierarchy and adds some padding to the top margin for a more centered, refined appearance of our forms.

Changed all forms on SoloConnect to inherit from form_base.html and put the forms themselves and any related page content in between the {% block form %} {% endblock form %} tags.

If this PR is merged, we will need to create future forms by extending form_base.html and using block form and endblock form tags.

Also added some top padding to the topmost row on the view_trips and detail_trip templates for a more centered appearance.