### PR TITLE
Feature: Form Calendar Field and Conditional Form Display

### DIFF
--- a/static/trip/js/form-conditional-display.js
+++ b/static/trip/js/form-conditional-display.js
@@ -1,0 +1,118 @@
+let cityField = document.getElementById("city-create-field");
+let countryField = document.getElementById("country-create-field");
+
+const CITY_CHOICES = {
+    "INDIA": [
+        "Ahmedabad",
+        "Bangalore",
+        "Chennai",
+        "Hyderabad",
+        "Jaipur",
+        "Kolkata",
+        "Mumbai",
+        "New Delhi",
+        "Pune"
+    ],
+    "UK": [
+        "Bristol",
+        "Glasgow",
+        "Leeds",
+        "Liverpool",
+        "London",
+        "Newcastle",
+        "Nottingham",
+        "Sheffield"
+    ],
+    "US": [
+        "Chicago",
+        "Dallas",
+        "Houston",
+        "Los Angeles",
+        "New York City",
+        "Phoenix",
+        "Philadelphia",
+        "San Antonio",
+        "San Diego"
+    ],
+    "CANADA": [
+        "Calgary",
+        "Edmonton",
+        "Hamilton",
+        "Mississauga",
+        "Montreal",
+        "Niagara Falls",
+        "Ottawa",
+        "Quebec City",
+        "Toronto",
+        "Vancouver"
+    ],
+    "MEXICO": [
+        "Cancun",
+        "Chichen Itza",
+        "Guadalajara",
+        "Los Cabos",
+        "Mexico City",
+        "Oaxaca City",
+        "Playa del Carmen",
+        "Puerto Vallarte"
+    ],
+    "FRANCE": [
+        "Burgundy",
+        "Bordeaux",
+        "Cannes",
+        "Corsica",
+        "Eze",
+        "Marseille",
+        "Nice",
+        "Normandy",
+        "Paris",
+        "Toulouse"
+    ],
+    "ITALY": [
+        "Florence",
+        "Genoa",
+        "Milan",
+        "Naples",
+        "Palermo",
+        "Rome",
+        "Venice"
+    ]
+}
+
+countryField.addEventListener('change', (e) => {
+
+    let inUse;
+
+    switch (countryField.value) {
+        case 'India':
+            inUse = CITY_CHOICES["INDIA"];
+            break;
+        case 'United Kingdom':
+            inUse = CITY_CHOICES["UK"];
+            break;
+        case 'United States':
+            inUse = CITY_CHOICES["US"];
+            break;
+        case 'Canada':
+            inUse = CITY_CHOICES["CANADA"];
+            break;
+        case 'Mexico':
+            inUse = CITY_CHOICES["MEXICO"];
+            break;
+        case 'Italy':
+            inUse = CITY_CHOICES["ITALY"];
+            break;
+        case 'France':
+            inUse = CITY_CHOICES["FRANCE"];
+            break;
+    }
+
+    for (let child of cityField.children) {
+        if (!inUse.includes(child.innerHTML)) {
+            child.style.display = 'none';
+        } else {
+            child.style.display = 'block';
+        }
+    }
+})
+

--- a/trip/forms.py
+++ b/trip/forms.py
@@ -13,11 +13,16 @@ from .helpers import (
 class UserTripCreationForm(forms.ModelForm):
     travel_type = forms.ChoiceField(choices=TRAVEL_TYPE, widget=forms.RadioSelect())
 
-    destination_city_ef = forms.MultipleChoiceField(
-        choices=CITY_CHOICES, label="Destination City"
-    )
     destination_country_ef = forms.MultipleChoiceField(
-        choices=COUNTRY_CHOICES, label="Destination Country"
+        choices=COUNTRY_CHOICES,
+        label="Destination Country",
+        widget=forms.SelectMultiple(attrs={"id": "country-create-field"})
+    )
+
+    destination_city_ef = forms.MultipleChoiceField(
+        choices=CITY_CHOICES,
+        label="Destination City",
+        widget=forms.SelectMultiple(attrs={"id": "city-create-field"})
     )
 
     def clean(self):
@@ -39,6 +44,13 @@ class UserTripCreationForm(forms.ModelForm):
     class Meta:
         model = UserTrip
         fields = ("start_trip", "end_trip", "travel_type")
+        widgets = {
+            "start_trip": forms.widgets.DateInput(attrs={"type": "date"}),
+            "end_trip": forms.widgets.DateInput(attrs={"type": "date"}),
+        }
+
+    class Media:
+        js = ["trip/js/form-conditional-display.js"]
 
 
 class UserTripUpdateForm(forms.ModelForm):
@@ -57,3 +69,7 @@ class UserTripUpdateForm(forms.ModelForm):
     class Meta:
         model = UserTrip
         fields = ("start_trip", "end_trip", "travel_type")
+        widgets = {
+            "start_trip": forms.widgets.DateInput(attrs={"type": "date"}),
+            "end_trip": forms.widgets.DateInput(attrs={"type": "date"}),
+        }

--- a/trip/forms.py
+++ b/trip/forms.py
@@ -16,13 +16,13 @@ class UserTripCreationForm(forms.ModelForm):
     destination_country_ef = forms.MultipleChoiceField(
         choices=COUNTRY_CHOICES,
         label="Destination Country",
-        widget=forms.SelectMultiple(attrs={"id": "country-create-field"})
+        widget=forms.SelectMultiple(attrs={"id": "country-create-field"}),
     )
 
     destination_city_ef = forms.MultipleChoiceField(
         choices=CITY_CHOICES,
         label="Destination City",
-        widget=forms.SelectMultiple(attrs={"id": "city-create-field"})
+        widget=forms.SelectMultiple(attrs={"id": "city-create-field"}),
     )
 
     def clean(self):

--- a/trip/static/trip/js/form-conditional-display.js
+++ b/trip/static/trip/js/form-conditional-display.js
@@ -1,0 +1,118 @@
+let cityField = document.getElementById("city-create-field");
+let countryField = document.getElementById("country-create-field");
+
+const CITY_CHOICES = {
+    "INDIA": [
+        "Ahmedabad",
+        "Bangalore",
+        "Chennai",
+        "Hyderabad",
+        "Jaipur",
+        "Kolkata",
+        "Mumbai",
+        "New Delhi",
+        "Pune"
+    ],
+    "UK": [
+        "Bristol",
+        "Glasgow",
+        "Leeds",
+        "Liverpool",
+        "London",
+        "Newcastle",
+        "Nottingham",
+        "Sheffield"
+    ],
+    "US": [
+        "Chicago",
+        "Dallas",
+        "Houston",
+        "Los Angeles",
+        "New York City",
+        "Phoenix",
+        "Philadelphia",
+        "San Antonio",
+        "San Diego"
+    ],
+    "CANADA": [
+        "Calgary",
+        "Edmonton",
+        "Hamilton",
+        "Mississauga",
+        "Montreal",
+        "Niagara Falls",
+        "Ottawa",
+        "Quebec City",
+        "Toronto",
+        "Vancouver"
+    ],
+    "MEXICO": [
+        "Cancun",
+        "Chichen Itza",
+        "Guadalajara",
+        "Los Cabos",
+        "Mexico City",
+        "Oaxaca City",
+        "Playa del Carmen",
+        "Puerto Vallarte"
+    ],
+    "FRANCE": [
+        "Burgundy",
+        "Bordeaux",
+        "Cannes",
+        "Corsica",
+        "Eze",
+        "Marseille",
+        "Nice",
+        "Normandy",
+        "Paris",
+        "Toulouse"
+    ],
+    "ITALY": [
+        "Florence",
+        "Genoa",
+        "Milan",
+        "Naples",
+        "Palermo",
+        "Rome",
+        "Venice"
+    ]
+}
+
+countryField.addEventListener('change', (e) => {
+
+    let inUse;
+
+    switch (countryField.value) {
+        case 'India':
+            inUse = CITY_CHOICES["INDIA"];
+            break;
+        case 'United Kingdom':
+            inUse = CITY_CHOICES["UK"];
+            break;
+        case 'United States':
+            inUse = CITY_CHOICES["US"];
+            break;
+        case 'Canada':
+            inUse = CITY_CHOICES["CANADA"];
+            break;
+        case 'Mexico':
+            inUse = CITY_CHOICES["MEXICO"];
+            break;
+        case 'Italy':
+            inUse = CITY_CHOICES["ITALY"];
+            break;
+        case 'France':
+            inUse = CITY_CHOICES["FRANCE"];
+            break;
+    }
+
+    for (let child of cityField.children) {
+        if (!inUse.includes(child.innerHTML)) {
+            child.style.display = 'none';
+        } else {
+            child.style.display = 'block';
+        }
+    }
+})
+

--- a/trip/static/trip/js/form-conditional-display.js
+++ b/trip/static/trip/js/form-conditional-display.js
@@ -105,13 +105,18 @@ countryField.addEventListener('change', (e) => {
         case 'France':
             inUse = CITY_CHOICES["FRANCE"];
             break;
+        default:
+            inUse = null;
+            break;
     }
 
-    for (let child of cityField.children) {
-        if (!inUse.includes(child.innerHTML)) {
-            child.style.display = 'none';
-        } else {
-            child.style.display = 'block';
+    if (inUse != null) {
+        for (let child of cityField.children) {
+            if (!inUse.includes(child.innerHTML)) {
+                child.style.display = 'none';
+            } else {
+                child.style.display = 'block';
+            }
         }
     }
 })

--- a/trip/templates/trip/create_trip.html
+++ b/trip/templates/trip/create_trip.html
@@ -1,10 +1,11 @@
 {% extends "home_default/form_base.html" %}
 {% load crispy_forms_tags %}
 {% block form %}
-<form method="POST">
+<form method="POST" id="trip-creation-form">
     {% csrf_token %}
     {{ form | crispy }}
     <br>
     <input type="submit" value="Submit" />
 </form>
+{{ form.media }}
 {% endblock form %}


### PR DESCRIPTION
Changes:
- In trip/forms.py, added widgets for date input (calendar) to end_trip and start_trip fields
- In trip/forms.py, added ids to country and city selection field to be able to retrieve them in JavaScript
- Inside UserTripCreationForm, added a Media class, which will house the JS file linked to it
- Pulled from Media class in the corresponding template
- In the corresponding template, added an id to the trip creation form
- Created a new static directory in trips and ran collectstatic to get it into the media root
- Inside the js folder of the trips static directory, created a JavaScript file, form-conditional-display.js, which has logic that will hide the <option> elements in the city field that our form generates depending on which country is chosen