### PR TITLE
Chat Rooms Fix

### DIFF
--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -63,10 +63,12 @@ class ChatConsumer(WebsocketConsumer):
         super().__init__(args, kwargs)
         self.user = None
         self.chat_room = None
+        self.thread_for_room = None
 
     def connect(self):
         self.user = self.scope["user"]
-        self.chat_room = f"user_chatroom_{self.user.id}"
+        self.thread_for_room = self.scope["url_route"]["kwargs"]["thread_id"]
+        self.chat_room = f"user_chatroom_{self.user.id}_thread_{self.thread_for_room}"
         async_to_sync(self.channel_layer.group_add)(self.chat_room, self.channel_name)
         self.accept()
 
@@ -93,7 +95,7 @@ class ChatConsumer(WebsocketConsumer):
         if not thread_instance:
             print("Error: thread instance is incorrect")
 
-        target_chat_room = f"user_chatroom_{receiving_user_id}"
+        target_chat_room = f"user_chatroom_{receiving_user_id}_thread_{thread_id}"
 
         self.create_chatmessage_object(thread_instance, sending_user_instance, message)
 

--- a/chat/routing.py
+++ b/chat/routing.py
@@ -3,5 +3,5 @@ from django.urls import re_path
 from . import consumers
 
 websocket_urlpatterns = [
-    re_path(r"ws/socket-server", consumers.ChatConsumer.as_asgi()),
+    re_path(r"ws/socket-server/(?P<thread_id>\d+)$", consumers.ChatConsumer.as_asgi()),
 ]

--- a/chat/templates/chat/message_room.html
+++ b/chat/templates/chat/message_room.html
@@ -24,7 +24,7 @@
     let selfUserId = jsonData["self_user_id"];
     let otherUserId = jsonData["other_user_id"];
 
-    let url = `ws://${window.location.host}/ws/socket-server`;
+    let url = `ws://${window.location.host}/ws/socket-server/${threadId}`;
 
     let chatSocket = new WebSocket(url);
 

--- a/chat/templates/chat/threads.html
+++ b/chat/templates/chat/threads.html
@@ -6,25 +6,18 @@
     <div class="row">
         <div class="col-3">
             <div id="chat-threads-list">
-                <ul>
                 {% for thread in threads %}
                    {% if thread.first_user == request.user %}
-                            <script>
-                                console.log("Chat with second user");
-                            </script>
-                           <a href="{% url 'chat:messages_page' thread_id=thread.id other_user_id=thread.second_user.id %}" class="chat-logs-links" id="chat_link_{{ thread.id }}">
-                               Chat with {{ thread.second_user.username }}
-                           </a>
+                       <a href="{% url 'chat:messages_page' thread_id=thread.id other_user_id=thread.second_user.id %}" class="chat-logs-links" id="chat_link_{{ thread.id }}">
+                           Chat with {{ thread.second_user.username }}
+                       </a>
                    {% else %}
-                           <a href="{% url 'chat:messages_page' thread_id=thread.id other_user_id=thread.first_user.id %}" class="chat-logs-links" id="chat_link_{{ thread.id }}">
-                               Chat with {{ thread.first_user.username }}
-                           </a>
-                            <script>
-                                console.log("Chat with first user");
-                            </script>
+                       <a href="{% url 'chat:messages_page' thread_id=thread.id other_user_id=thread.first_user.id %}" class="chat-logs-links" id="chat_link_{{ thread.id }}">
+                           Chat with {{ thread.first_user.username }}
+                       </a>
                    {% endif %}
+                    <br>
                 {% endfor %}
-                </ul>
             </div>
         </div>
     </div>

--- a/soloconnect/settings.py
+++ b/soloconnect/settings.py
@@ -182,11 +182,11 @@ CHANNEL_LAYERS = {
         "CONFIG": {
             "hosts": [
                 # todo Uncomment host and comment redis url if you want to run locally
-                # ("127.0.0.1", 6379)
-                (
-                    "sc-redis.45ncis.ng.0001.use1.cache.amazonaws.com",
-                    6379,
-                ),
+                ("127.0.0.1", 6379)
+                # (
+                #     "sc-redis.45ncis.ng.0001.use1.cache.amazonaws.com",
+                #     6379,
+                # ),
             ],
         },
         "CACHES": {

--- a/soloconnect/settings.py
+++ b/soloconnect/settings.py
@@ -182,11 +182,11 @@ CHANNEL_LAYERS = {
         "CONFIG": {
             "hosts": [
                 # todo Uncomment host and comment redis url if you want to run locally
-                ("127.0.0.1", 6379)
-                # (
-                #     "sc-redis.45ncis.ng.0001.use1.cache.amazonaws.com",
-                #     6379,
-                # ),
+                # ("127.0.0.1", 6379)
+                (
+                    "sc-redis.45ncis.ng.0001.use1.cache.amazonaws.com",
+                    6379,
+                ),
             ],
         },
         "CACHES": {


### PR DESCRIPTION
Previously, when we would be sending messages, we would be sending them to a chat room called

"user_chatroom_{user_id}"

This led to issues because, if a user would be chatting with another user, and a third user sent a message to them, the message would go into the chat room between users A and B.

This is patched now

Changes:
- Edited URL routing to take the thread ID as a parameter, so when we establish a websocket connection from the front end, we'll be able to tell the consumer (through self.scope['url_route']['kwargs']['thread_id']) which thread we're on
- Edited websocket connection on the front end
- Changed the user chatroom name construction to "user_chatroom_{user_id}_thread_{thread_id}" so now each user has a logically separate chatroom for each thread they participate in
- Minor stylistic changes to the front end (line breaks in threads page)