### PR TITLE
Chat Render Typo Fix

### DIFF
--- a/chat/templates/chat/message_room.html
+++ b/chat/templates/chat/message_room.html
@@ -168,7 +168,7 @@
                                         <img src="{{ curr_message.thread.second_user_image_url }}" class="img-fluid rounded-circle" alt="image">
                                         {{ curr_message.thread.first_user_image_url }}
                                     </div>
-                                    <div class="card card-text-sent-to p-2 px-3 m-1 d-inline-block" style="max-width: 60%;">>
+                                    <div class="card card-text-sent-to p-2 px-3 m-1 d-inline-block" style="max-width: 60%;">
                                         {{ curr_message.sending_user.first_name }} {{ curr_message.sending_user.last_name|slice:":1" }}. : {{ curr_message.message }}
                                     </div>
                                 </div>


### PR DESCRIPTION
Fixed a typo that led to chat messages pulled in from history to render as

">fname last_initial.: message"

Instead of 

"fname last_initial.: message"